### PR TITLE
Fix small bugs: support utf-8 chars and getPixmap interface change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+document_contents_extractor.egg-info/
+venv/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal"
+        },
+        {
+            "name": "extract_contents",
+            "type": "python",
+            "request": "launch",
+            "program": "extract_contents",
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "args": [
+                // "c:/temp/test_content_extractor/dk_maths.pdf",
+                // "5", // should be physical page number (the larger one)
+                // "7", // the real last page,  no need to add 1
+                "c:/temp/test_content_extractor/12092235.pdf",
+                "1",
+                "2",
+                "-f",
+                "-l",
+                "chi_sim",
+                // "-p",
+                // "1"
+            ]
+        }
+    ]
+}

--- a/extract_contents
+++ b/extract_contents
@@ -15,7 +15,7 @@ parser = argparse.ArgumentParser(description='Extract contents as text from a pd
 parser.add_argument('filename', help='a PDF-file and contents page range')
 parser.add_argument('firstpage', type=int, help='start pagenumber')
 parser.add_argument('lastpage', type=int, help='end pagenumber')
-parser.add_argument('-o', metavar='STRING', default = 'contents_ocr.txt', type=argparse.FileType('w'))
+parser.add_argument('-o', metavar='STRING', default = 'contents_ocr.txt', type=argparse.FileType('w', encoding="utf-8"))
 parser.add_argument('-p', '--psm', metavar='INT', default=6, type=int, help='optional tesseract psm setting (default 6). Try 1 for multicolumn contents')
 parser.add_argument('-m', '--mag', metavar='FLOAT', default='2.0', type=float, help='optional magnification factor for better OCR (default=2.0)')
 parser.add_argument('-r', '--res', metavar='INT', default='300', type=int, help='optional resolution for better OCR (default=300 and is recommended minimum)')
@@ -82,7 +82,7 @@ if args.filename.endswith('pdf'):
             for i in range(args.firstpage - 1, args.lastpage, 1):
                 print(i)
                 page = doc[i]
-                pix = page.getPixmap(mat)
+                pix = page.get_pixmap(matrix=mat)
                 imdata = pix.getImageData()
                 bytesim = BytesIO(imdata)
                 page_string = pytesseract.image_to_string(Image.open(bytesim), lang=args.lang, config='--psm {}'.format(args.psm)).split('\n')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Pillow==6.1.0
-PyMuPDF==1.14.17
+PyMuPDF
 pytesseract==0.2.7


### PR DESCRIPTION
Hello there

Thanks for creating the package. It is so much fun to create TOC by OCR instead of manual input.
Just fix some small bugs.
1. Support utf-8 chars in TOC
2. I guess In my Windows 10 machine, simply running a pip install seems installing a slightly different fitz as in your machine. 1) The getPixmap only allow 1 position argument (the `self`), mat has to be passed as keyword argument.  2) getPixmap is deprecated. My fix should be work for both old fitz and new fitz.